### PR TITLE
474: fix cargo invite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ burn: zip
 	mix upload
 
 ssh:
-	ssh -i ~/.ssh/buckit.id_rsa nerves.local
+	ssh -i ~/.ssh/buckit.id_rsa -o "StrictHostKeyChecking=no" nerves.local
 
 burn_in: burn await_restart ssh
 


### PR DESCRIPTION
We've broken checkpoints invite w/ checkpoints changes to contain a user card, instead of pub key. This is why cargo invites was not found to be sent on cargo drive.